### PR TITLE
Enable Keyboard While Running on OS X if in -d

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1063,7 +1063,7 @@ void CFrame::OnKeyDown(wxKeyEvent& event)
 	// the system beep for unhandled key events when
 	// receiving pad/Wiimote keypresses which take an
 	// entirely different path through the HID subsystem.
-#ifndef __APPLE__
+#if defined __APPLE__ && (defined(_DEBUG) || defined(DEBUGFAST))
 	// On other platforms, we leave the key event alone
 	// so it can be passed on to the windowing system.
 	event.Skip();


### PR DESCRIPTION
Without keypresses registering with a game running, several debug menu options were unusable.